### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,22 +48,23 @@
 
   <dependencies>
 
-    <dependency>
+   <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.9</version>
+      <version>2.5.3</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9</version>
+      <version>2.5.3</version>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jdk7 -->
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
-      <version>2.9.9</version>
+      <artifactId>jackson-datatype-jdk7</artifactId>
+      <version>2.6.7</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
降低了jackson-core，jackson-databind的版本，将jackson-datatype-jdk8修改为jackson-datatype-jdk7，用以在java7的环境下使用